### PR TITLE
Handle 403 head_object errors gracefully

### DIFF
--- a/backend/src/media_storage/mod.rs
+++ b/backend/src/media_storage/mod.rs
@@ -108,8 +108,21 @@ impl MediaStorage {
 
         match result {
             Ok(_) => Ok(true),
+            // In production we've disabled s3:ListBucket permission for the bucket for security reasons
+            // We still handle the case as fallback and log a warning message for this path
             Err(SdkError::ServiceError(service_err))
                 if matches!(service_err.err(), HeadObjectError::NotFound(_)) =>
+            {
+                tracing::warn!(
+                    "head_object returned NotFound, indicating S3:ListBucket permission is granted"
+                );
+                Ok(false)
+            }
+            // In production we've disabled s3:ListBucket permission for the bucket for security reasons
+            // In that case head_object will return 403 if the object doesn't exist
+            // More details [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html)
+            Err(SdkError::ServiceError(service_err))
+                if service_err.raw().status().as_u16() == 403 =>
             {
                 Ok(false)
             }


### PR DESCRIPTION
This PR handles 403 errors gracefully when calling `head_object`. The production bucket does NOT have `s3:ListObject` permission so it returns 403 response when an object is missing [relevant docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html)

I tried emulating IAM policies in localstack, but this required a paid plan, nonetheless I tested this on staging and it works.