### PR TITLE
INFRA-5042: build images for all applications and for enclave

### DIFF
--- a/enclave-worker/Dockerfile
+++ b/enclave-worker/Dockerfile
@@ -1,0 +1,37 @@
+
+########################################################
+#### Builder
+########################################################
+
+FROM clux/muslrust:stable AS chef
+USER root
+RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin enclave-worker
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN) && \
+    git config --global url."https://${GITHUB_TOKEN}@github.com/worldcoin/".insteadOf "https://github.com/worldcoin/"
+
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json --package enclave-worker --bin enclave-worker
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl --package enclave-worker
+
+########################################################
+#### Runner
+########################################################
+FROM alpine AS runtime
+RUN addgroup -S rust && adduser -S rust -G rust
+WORKDIR /app
+
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/enclave-worker /usr/local/bin/
+
+USER rust
+CMD ["/usr/local/bin/enclave-worker"]

--- a/secure-enclave/Dockerfile
+++ b/secure-enclave/Dockerfile
@@ -1,0 +1,37 @@
+
+########################################################
+#### Builder
+########################################################
+
+FROM clux/muslrust:stable AS chef
+USER root
+RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin secure-enclave
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN) && \
+    git config --global url."https://${GITHUB_TOKEN}@github.com/worldcoin/".insteadOf "https://github.com/worldcoin/"
+
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json --package secure-enclave --bin secure-enclave
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl --package secure-enclave
+
+########################################################
+#### Runner
+########################################################
+FROM alpine AS runtime
+RUN addgroup -S rust && adduser -S rust -G rust
+WORKDIR /app
+
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/secure-enclave /usr/local/bin/
+
+USER rust
+CMD ["/usr/local/bin/secure-enclave"]


### PR DESCRIPTION
Requestor/Issue: INFRA-5042
Tested (yes/no): no
Description/Why: This PR add Dockerfiles to application `enclave-worker` and `secure-enclave` based on files used with deepface application https://github.com/worldcoin/df-enclave-poc/blob/main/enclave/Dockerfile. Files are require to build enclave images with github workflow with repo https://github.com/worldcoin/world-chat-backend-deploy/pull/9