### PR TITLE
feat: Add media config endpoint

### DIFF
--- a/backend/src/routes/v1/media.rs
+++ b/backend/src/routes/v1/media.rs
@@ -16,6 +16,8 @@ use crate::{
 const MAX_IMAGE_SIZE_BYTES: i64 = 5 * 1024 * 1024;
 /// 15 MB Video size limit
 const MAX_VIDEO_SIZE_BYTES: i64 = 15 * 1024 * 1024;
+/// Maximum count of assets per message
+const MAX_ASSETS_PER_MESSAGE: usize = 10;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
@@ -137,4 +139,23 @@ fn validate_asset_size(content_type: &Mime, content_length: i64) -> Result<(), A
         )),
         _ => Ok(()),
     }
+}
+
+#[derive(Serialize, JsonSchema)]
+pub struct MediaConfigResponse {
+    /// Maximum count of assets per message
+    max_assets_per_message: usize,
+    /// Maximum image size in bytes
+    max_image_size_bytes: i64,
+    /// Maximum video size in bytes
+    max_video_size_bytes: i64,
+}
+
+#[instrument]
+pub async fn get_media_config() -> Json<MediaConfigResponse> {
+    Json(MediaConfigResponse {
+        max_assets_per_message: MAX_ASSETS_PER_MESSAGE,
+        max_image_size_bytes: MAX_IMAGE_SIZE_BYTES,
+        max_video_size_bytes: MAX_VIDEO_SIZE_BYTES,
+    })
 }

--- a/backend/src/routes/v1/mod.rs
+++ b/backend/src/routes/v1/mod.rs
@@ -1,7 +1,10 @@
 pub mod auth;
 pub mod media;
 
-use aide::axum::{routing::post, ApiRouter};
+use aide::axum::{
+    routing::{get, post},
+    ApiRouter,
+};
 
 /// Creates the v1 API router with all v1 handler routes
 pub fn handler() -> ApiRouter {
@@ -10,5 +13,6 @@ pub fn handler() -> ApiRouter {
             "/media/presigned-urls",
             post(media::create_presigned_upload_url),
         )
+        .api_route("/media/config", get(media::get_media_config))
         .api_route("/authorize", post(auth::authorize_handler))
 }


### PR DESCRIPTION
This PR adds a new endpoint that serves media config, meant to be used by the client.

I chose to serve config from chat backend in order to have a single soure of truth and make it easy to change these limits in the future. 