### PR TITLE
build: Fix docker caching 

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,12 +23,12 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build stage - cooks dependencies then builds application
 FROM chef AS builder
 
-ARG GIT_REV
-ENV GIT_REV=${GIT_REV}
-
 # Copy recipe and build dependencies (cached if unchanged)
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+
+ARG GIT_REV
+ENV GIT_REV=${GIT_REV}
 
 # Copy source code and build application
 COPY . .

--- a/enclave-worker/Dockerfile
+++ b/enclave-worker/Dockerfile
@@ -21,12 +21,12 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build stage - cooks dependencies then builds application
 FROM chef AS builder
 
-ARG GIT_REV
-ENV GIT_REV=${GIT_REV}
-
 # Copy recipe and build dependencies (cached if unchanged)
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
+
+ARG GIT_REV
+ENV GIT_REV=${GIT_REV}
 
 # Copy source code and build application
 COPY . .

--- a/notification-worker/Dockerfile
+++ b/notification-worker/Dockerfile
@@ -24,12 +24,12 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build stage - cooks dependencies then builds application
 FROM chef AS builder
 
-ARG GIT_REV
-ENV GIT_REV=${GIT_REV}
-
 # Copy recipe and build dependencies (cached if unchanged)
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --target x86_64-unknown-linux-musl --recipe-path recipe.json
+
+ARG GIT_REV
+ENV GIT_REV=${GIT_REV}
 
 # Copy source code and build application
 COPY . .


### PR DESCRIPTION
This PR fixes issues with docker caching, by moving the `GIT_REV` argument after `cargo chef cook` command which builds the depedencies.

`GIT_REV` argument was introduced to make sure we build the every time, building the depedencies again wans't intented.