### PR TITLE
feat: Integrate push id challenges 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1232,6 +1232,7 @@ version = "0.1.0"
 dependencies = [
  "aide",
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-dynamodb",
@@ -1240,6 +1241,7 @@ dependencies = [
  "aws-sdk-sqs",
  "axum 0.7.9",
  "axum-jsonschema",
+ "backend",
  "backend_storage",
  "base64 0.22.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,7 @@ dependencies = [
  "backend_storage",
  "base64 0.22.1",
  "chrono",
+ "common-types",
  "datadog-tracing",
  "dotenvy",
  "futures",
@@ -1675,6 +1676,14 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "common-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ members = [
     "secure-enclave",
     "shared/backend_storage",
     "notification-worker",
+     # TODO remove this and move types to common-types
     "shared/enclave-types",
+    "shared/common-types",
 ]
 resolver = "2"
 
@@ -86,6 +88,9 @@ hmac = "0.12.1"
 
 # Enclave types
 enclave-types = { path = "shared/enclave-types" }
+
+# Common types 
+common-types = { path = "shared/common-types" }
 
 # Datadog tracing
 datadog-tracing = { version = "0.3.0", features = ["axum"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tower-http = { version = "0.6.2", features = ["trace", "timeout"] }
 tokio = { version = "1.47.1", features = ["full"] }
 tokio-util = { version = "0.7.11" }
 futures = "0.3.31"
+async-trait = "0.1.89"
 
 # Serialization
 serde      = { version = "1.0", features = ["derive"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -67,6 +67,8 @@ mime = { workspace = true }
 p256 = { workspace = true }
 sha2 = { workspace = true }
 
+common-types = { workspace = true }
+
 [dev-dependencies]
 http-body-util = { workspace = true }
 tower = { workspace = true }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ tower-http = { workspace = true }
 # Async 
 tokio = { workspace = true }
 futures = { workspace = true }
+async-trait = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
@@ -69,7 +70,11 @@ sha2 = { workspace = true }
 
 common-types = { workspace = true }
 
+[features]
+test-utils = []
+
 [dev-dependencies]
+backend = { path = ".", features = ["test-utils"] }
 http-body-util = { workspace = true }
 tower = { workspace = true }
 tokio-test = { workspace = true }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod jwt;
 pub mod media_storage;
 pub mod middleware;
+pub mod push_id_challenger;
 pub mod routes;
 pub mod server;
 pub mod types;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Initalize Push ID challenger
     let push_id_challenger: Arc<dyn PushIdChallenger> =
-        Arc::new(PushIdChallengerImpl::new(environment.enclave_http_url()));
+        Arc::new(PushIdChallengerImpl::new(environment.enclave_worker_url()));
 
     let result = server::start(
         environment,

--- a/backend/src/push_id_challenger/mod.rs
+++ b/backend/src/push_id_challenger/mod.rs
@@ -1,0 +1,81 @@
+use common_types::{PushIdChallengeRequest, PushIdChallengeResponse};
+use std::time::Duration;
+
+use crate::types::AppError;
+use reqwest::Client;
+
+/// Default timeout for push id challenger requests
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+/// Maximum number of idle connections to maintain per host
+const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 10;
+
+pub trait PushIdChallenger {
+    async fn challenge_push_ids(
+        &self,
+        push_id_1: String,
+        push_id_2: String,
+    ) -> Result<bool, AppError>;
+}
+
+pub struct PushIdChallengerImpl {
+    enclave_url: String,
+    http_client: Client,
+}
+
+impl PushIdChallengerImpl {
+    pub fn new(enclave_url: String) -> Self {
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS))
+            .pool_max_idle_per_host(MAX_IDLE_CONNECTIONS_PER_HOST)
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            enclave_url,
+            http_client,
+        }
+    }
+}
+
+impl PushIdChallenger for PushIdChallengerImpl {
+    async fn challenge_push_ids(
+        &self,
+        push_id_1: String,
+        push_id_2: String,
+    ) -> Result<bool, AppError> {
+        let request = PushIdChallengeRequest {
+            push_id_1,
+            push_id_2,
+        };
+
+        let response = self
+            .http_client
+            .post(&self.enclave_url)
+            .json(&request)
+            .send()
+            .await?
+            .json::<PushIdChallengeResponse>()
+            .await?;
+
+        Ok(response.push_ids_match)
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+
+    pub struct MockPushIdChallenger {
+        push_ids_match: bool,
+    }
+
+    impl PushIdChallenger for MockPushIdChallenger {
+        async fn challenge_push_ids(
+            &self,
+            _push_id_1: String,
+            _push_id_2: String,
+        ) -> Result<bool, AppError> {
+            Ok(self.push_ids_match)
+        }
+    }
+}

--- a/backend/src/push_id_challenger/mod.rs
+++ b/backend/src/push_id_challenger/mod.rs
@@ -68,7 +68,7 @@ impl PushIdChallenger for PushIdChallengerImpl {
 
         let response = self
             .http_client
-            .post(format!("{}/push-id-challenge", self.enclave_worker_url))
+            .post(format!("{}/v1/push-id-challenge", self.enclave_worker_url))
             .json(&request)
             .send()
             .await?

--- a/backend/src/push_id_challenger/mod.rs
+++ b/backend/src/push_id_challenger/mod.rs
@@ -11,6 +11,8 @@ const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 10;
 
 #[async_trait::async_trait]
 pub trait PushIdChallenger: Send + Sync {
+    /// Challenge 2 encrypted push ids by sending them to the enclave that can decrypt them
+    /// returns true if they match.
     async fn challenge_push_ids(
         &self,
         encrypted_push_id_1: String,

--- a/backend/src/push_id_challenger/mod.rs
+++ b/backend/src/push_id_challenger/mod.rs
@@ -26,7 +26,9 @@ pub struct PushIdChallengerImpl {
 impl PushIdChallengerImpl {
     /// Creates a new push id challenger
     ///
-    /// # Panics if the HTTP client fails to be created
+    /// # Panics
+    ///
+    /// If the HTTP client fails to be created
     #[must_use]
     pub fn new(enclave_url: String) -> Self {
         let http_client = Client::builder()
@@ -74,7 +76,7 @@ impl PushIdChallenger for PushIdChallengerImpl {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod mock {
-    use super::*;
+    use super::{AppError, PushIdChallenger};
 
     pub struct MockPushIdChallenger {
         override_push_ids_match: Option<bool>,
@@ -82,7 +84,7 @@ pub mod mock {
 
     impl MockPushIdChallenger {
         #[must_use]
-        pub fn new(override_push_ids_match: Option<bool>) -> Self {
+        pub const fn new(override_push_ids_match: Option<bool>) -> Self {
             Self {
                 override_push_ids_match,
             }

--- a/backend/src/routes/v1/auth.rs
+++ b/backend/src/routes/v1/auth.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::Extension;
+use axum::{http::StatusCode, Extension};
 use axum_jsonschema::Json;
 use backend_storage::auth_proof::{AuthProofInsertRequest, AuthProofStorage};
 use chrono::Utc;
@@ -11,9 +11,13 @@ use walletkit_core::CredentialType;
 
 use crate::{
     jwt::{JwsPayload, JwtManager},
+    push_id_challenger::PushIdChallenger,
     types::{AppError, Environment},
     world_id::{error::WorldIdError, verifier::verify_world_id_proof},
 };
+
+/// The threshold for the last push id rotation in seconds
+const PUSH_ID_ROTATION_THRESHOLD_SECS: i64 = 6 * 30 * 24 * 60 * 60; // 6 months
 
 #[derive(Deserialize, JsonSchema)]
 pub struct AuthRequest {
@@ -53,6 +57,7 @@ pub async fn authorize_handler(
     Extension(jwt_manager): Extension<Arc<JwtManager>>,
     Extension(auth_proof_storage): Extension<Arc<AuthProofStorage>>,
     Extension(environment): Extension<Environment>,
+    Extension(push_id_challenger): Extension<Arc<dyn PushIdChallenger>>,
     Json(request): Json<AuthRequest>,
 ) -> Result<Json<AuthResponse>, AppError> {
     // 1. Verify World ID proof
@@ -78,8 +83,46 @@ pub async fn authorize_handler(
         })
         .await?;
 
-    // 3. Issue JWT token with stored encrypted push id
-    let jws_payload = JwsPayload::from_encrypted_push_id(auth_proof.encrypted_push_id);
+    // 3. Challenge push ids
+    let push_ids_match = push_id_challenger
+        .challenge_push_ids(
+            auth_proof.encrypted_push_id.clone(),
+            request.encrypted_push_id.clone(),
+        )
+        .await?;
+
+    // 4.a If the push ids match, issue JWT token with stored encrypted push id
+    if push_ids_match {
+        let jws_payload = JwsPayload::from_encrypted_push_id(auth_proof.encrypted_push_id);
+        let access_token = jwt_manager.issue_token(&jws_payload).await?;
+
+        return Ok(Json(AuthResponse {
+            access_token,
+            expires_at: jws_payload.expires_at,
+        }));
+    }
+
+    // If the push ids don't match
+    // and the push id rotation is within the threshold, we return a 403
+    // This is to prevent abuse of the push id rotation
+    let is_push_id_rotation_within_threshold =
+        Utc::now().timestamp() <= auth_proof.push_id_rotated_at + PUSH_ID_ROTATION_THRESHOLD_SECS;
+    if is_push_id_rotation_within_threshold {
+        return Err(AppError::new(
+            StatusCode::FORBIDDEN,
+            "push_ids_mismatch",
+            "Push IDs mismatch",
+            false,
+        ));
+    }
+
+    // Otherwise, we update the encrypted push id and issue a JWT token with the new encrypted push id
+    auth_proof_storage
+        .update_encrypted_push_id(&auth_proof.nullifier, &request.encrypted_push_id.clone())
+        .await?;
+
+    // 5. Issue JWT token with stored encrypted push id
+    let jws_payload = JwsPayload::from_encrypted_push_id(request.encrypted_push_id);
     let access_token = jwt_manager.issue_token(&jws_payload).await?;
 
     Ok(Json(AuthResponse {

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -7,6 +7,7 @@ use backend_storage::push_subscription::PushSubscriptionStorage;
 use datadog_tracing::axum::{shutdown_signal, OtelAxumLayer, OtelInResponseLayer};
 use tokio::net::TcpListener;
 
+use crate::push_id_challenger::PushIdChallenger;
 use crate::routes;
 use crate::{jwt::JwtManager, media_storage::MediaStorage, types::Environment};
 
@@ -21,6 +22,7 @@ pub async fn start(
     jwt_manager: Arc<JwtManager>,
     auth_proof_storage: Arc<AuthProofStorage>,
     push_subscription_storage: Arc<PushSubscriptionStorage>,
+    push_id_challenger: Arc<dyn PushIdChallenger>,
 ) -> anyhow::Result<()> {
     let mut openapi = OpenApi::default();
 
@@ -32,6 +34,7 @@ pub async fn start(
         .layer(Extension(jwt_manager))
         .layer(Extension(auth_proof_storage))
         .layer(Extension(push_subscription_storage))
+        .layer(Extension(push_id_challenger))
         // Include trace context as header into the response
         .layer(OtelInResponseLayer)
         // Start OpenTelemetry trace on incoming request

--- a/backend/src/types/environment.rs
+++ b/backend/src/types/environment.rs
@@ -244,17 +244,26 @@ impl Environment {
         }
     }
 
-    /// Returns the Enclave HTTP URL that is used to challenge push IDs
+    /// Returns the Enclave Worker HTTP URL that is used to challenge push IDs
     ///
     /// # Panics
     ///
-    /// Panics if the `ENCLAVE_HTTP_URL` environment variable is not set in production/staging
+    /// Panics if the `ENCLAVE_WORKER_URL` environment variable is not set in production/staging
     #[must_use]
-    pub fn enclave_http_url(&self) -> String {
+    pub fn enclave_worker_url(&self) -> String {
         match self {
-            Self::Production | Self::Staging => env::var("ENCLAVE_HTTP_URL")
-                .expect("ENCLAVE_HTTP_URL environment variable is not set"),
-            Self::Development { .. } => "http://localhost:8004".to_string(),
+            Self::Production | Self::Staging => {
+                let url = env::var("ENCLAVE_WORKER_URL")
+                    .expect("ENCLAVE_WORKER_URL environment variable is not set");
+
+                assert!(
+                    url.starts_with("https://"),
+                    "Enclave Worker URL in Production/Staging must use https"
+                );
+
+                url
+            }
+            Self::Development { .. } => "http://localhost:8003".to_string(),
         }
     }
 }

--- a/backend/src/types/environment.rs
+++ b/backend/src/types/environment.rs
@@ -263,7 +263,7 @@ impl Environment {
 
                 url
             }
-            Self::Development { .. } => "http://localhost:8003".to_string(),
+            Self::Development { .. } => "http://localhost:8002".to_string(),
         }
     }
 }

--- a/backend/src/types/environment.rs
+++ b/backend/src/types/environment.rs
@@ -243,6 +243,20 @@ impl Environment {
             Self::Development { .. } => "world-chat-push-subscriptions".to_string(),
         }
     }
+
+    /// Returns the Enclave HTTP URL that is used to challenge push IDs
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `ENCLAVE_HTTP_URL` environment variable is not set in production/staging
+    #[must_use]
+    pub fn enclave_http_url(&self) -> String {
+        match self {
+            Self::Production | Self::Staging => env::var("ENCLAVE_HTTP_URL")
+                .expect("ENCLAVE_HTTP_URL environment variable is not set"),
+            Self::Development { .. } => "http://localhost:8004".to_string(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/types/error.rs
+++ b/backend/src/types/error.rs
@@ -379,3 +379,16 @@ impl From<JwtError> for AppError {
         }
     }
 }
+
+/// Convert reqwest errors to application errors
+impl From<reqwest::Error> for AppError {
+    fn from(err: reqwest::Error) -> Self {
+        tracing::error!("Reqwest error: {err:?}");
+        Self::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            "Internal server error",
+            false,
+        )
+    }
+}

--- a/shared/common-types/Cargo.toml
+++ b/shared/common-types/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "common-types"
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+# Error handling
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+

--- a/shared/common-types/src/lib.rs
+++ b/shared/common-types/src/lib.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PushIdChallengeRequest {
-    pub push_id_1: String,
-    pub push_id_2: String,
+    pub encrypted_push_id_1: String,
+    pub encrypted_push_id_2: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/shared/common-types/src/lib.rs
+++ b/shared/common-types/src/lib.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PushIdChallengeRequest {
+    pub push_id_1: String,
+    pub push_id_2: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PushIdChallengeResponse {
+    pub push_ids_match: bool,
+}


### PR DESCRIPTION
This PR integrated push id challenges in the auth flow.
- Added `PushIdChallenger` module, which accepts encrypted push IDs and makes a call to the `enclave-worker` to validate if they match.
- Integrated `PushIdChallenger` module in the auth flow; We allow push id rotation with a minimum threshold to prevent abuse.

Will tackle extensive tests for the new BL in a separate PR. 