### PR TITLE
feat: Add batch db operations for unsubscribe

### DIFF
--- a/backend/src/types/error.rs
+++ b/backend/src/types/error.rs
@@ -211,9 +211,9 @@ impl From<PushSubscriptionStorageError> for AppError {
     #[allow(clippy::cognitive_complexity)]
     fn from(err: PushSubscriptionStorageError) -> Self {
         use PushSubscriptionStorageError::{
-            DynamoDbDeleteError, DynamoDbGetError, DynamoDbPutError, DynamoDbQueryError,
-            DynamoDbUpdateError, ParseSubscriptionError, PushSubscriptionExists,
-            SerializationError,
+            DynamoDbBatchWriteError, DynamoDbDeleteError, DynamoDbGetError, DynamoDbPutError,
+            DynamoDbQueryError, DynamoDbUpdateError, ParseSubscriptionError,
+            PushSubscriptionExists, SerializationError,
         };
 
         match &err {
@@ -221,7 +221,8 @@ impl From<PushSubscriptionStorageError> for AppError {
             | DynamoDbDeleteError(_)
             | DynamoDbGetError(_)
             | DynamoDbQueryError(_)
-            | DynamoDbUpdateError(_) => {
+            | DynamoDbUpdateError(_)
+            | DynamoDbBatchWriteError(_) => {
                 tracing::error!("DynamoDB error: {err}");
                 Self::new(
                     StatusCode::SERVICE_UNAVAILABLE,

--- a/enclave-worker/src/types/error.rs
+++ b/enclave-worker/src/types/error.rs
@@ -91,9 +91,9 @@ impl OperationOutput for AppError {
 impl From<PushSubscriptionStorageError> for AppError {
     fn from(err: PushSubscriptionStorageError) -> Self {
         use PushSubscriptionStorageError::{
-            DynamoDbDeleteError, DynamoDbGetError, DynamoDbPutError, DynamoDbQueryError,
-            DynamoDbUpdateError, ParseSubscriptionError, PushSubscriptionExists,
-            SerializationError,
+            DynamoDbBatchWriteError, DynamoDbDeleteError, DynamoDbGetError, DynamoDbPutError,
+            DynamoDbQueryError, DynamoDbUpdateError, ParseSubscriptionError,
+            PushSubscriptionExists, SerializationError,
         };
 
         match &err {
@@ -112,7 +112,8 @@ impl From<PushSubscriptionStorageError> for AppError {
             | DynamoDbDeleteError(_)
             | DynamoDbGetError(_)
             | DynamoDbQueryError(_)
-            | DynamoDbUpdateError(_) => {
+            | DynamoDbUpdateError(_)
+            | DynamoDbBatchWriteError(_) => {
                 tracing::error!("DynamoDB error: {err}");
                 Self::new(
                     StatusCode::SERVICE_UNAVAILABLE,

--- a/shared/backend_storage/Cargo.toml
+++ b/shared/backend_storage/Cargo.toml
@@ -36,9 +36,10 @@ strum = { workspace = true }
 # Random number generation
 rand = { workspace = true }
 
+futures = { workspace = true }
+
 [dev-dependencies]
 tokio-test = { workspace = true }
 uuid = { workspace = true }
 aws-credential-types = { version = "1.2.5" , features = ["hardcoded-credentials"]}
 pretty_assertions = "1.4.1"
-futures = { workspace = true }

--- a/shared/backend_storage/src/push_subscription/error.rs
+++ b/shared/backend_storage/src/push_subscription/error.rs
@@ -2,8 +2,8 @@
 
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::{
-    delete_item::DeleteItemError, get_item::GetItemError, put_item::PutItemError,
-    query::QueryError, update_item::UpdateItemError,
+    batch_write_item::BatchWriteItemError, delete_item::DeleteItemError, get_item::GetItemError,
+    put_item::PutItemError, query::QueryError, update_item::UpdateItemError,
 };
 use thiserror::Error;
 
@@ -32,6 +32,10 @@ pub enum PushSubscriptionStorageError {
     /// Failed to update subscription in Dynamo DB
     #[error("Failed to update subscription in DynamoDB: {0}")]
     DynamoDbUpdateError(#[from] SdkError<UpdateItemError>),
+
+    /// Failed to batch write items to Dynamo DB
+    #[error("Failed to batch write items to DynamoDB: {0}")]
+    DynamoDbBatchWriteError(#[from] SdkError<BatchWriteItemError>),
 
     /// Failed to parse subscription from Dynamo DB item
     #[error("Failed to parse subscription: {0:?}")]

--- a/shared/backend_storage/src/push_subscription/mod.rs
+++ b/shared/backend_storage/src/push_subscription/mod.rs
@@ -4,13 +4,14 @@
 
 mod error;
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use aws_sdk_dynamodb::{
     error::SdkError,
-    types::{AttributeValue, Select},
+    types::{AttributeValue, DeleteRequest, Select, WriteRequest},
     Client as DynamoDbClient,
 };
+use futures::future;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -288,5 +289,132 @@ impl PushSubscriptionStorage {
             .await?;
 
         Ok(())
+    }
+
+    /// Gets all push subscriptions for a specific topic and `encrypted_push_id`
+    ///
+    /// This method queries all subscriptions for a topic and filters by `encrypted_push_id`
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic to query subscriptions for
+    /// * `encrypted_push_id` - The encrypted push ID to filter by
+    ///
+    /// # Returns
+    ///
+    /// A vector of push subscriptions matching the topic and `encrypted_push_id`
+    ///
+    /// # Errors
+    ///
+    /// Returns `PushSubscriptionStorageError` if the Dynamo DB operation fails
+    pub async fn get_all_by_topic_and_push_id(
+        &self,
+        topic: &str,
+        encrypted_push_id: &str,
+    ) -> PushSubscriptionStorageResult<Vec<PushSubscription>> {
+        let all_subscriptions = self.get_all_by_topic(topic).await?;
+
+        Ok(all_subscriptions
+            .into_iter()
+            .filter(|sub| sub.encrypted_push_id == encrypted_push_id)
+            .collect())
+    }
+
+    /// Batch delete multiple subscriptions by topic and `hmac_keys`
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic of the subscriptions to delete
+    /// * `hmac_keys` - The HMAC keys of the subscriptions to delete
+    ///
+    /// # Errors
+    ///
+    /// Returns `PushSubscriptionStorageError` if the Dynamo DB operation fails
+    pub async fn batch_delete(
+        &self,
+        topic: &str,
+        hmac_keys: &[String],
+    ) -> PushSubscriptionStorageResult<()> {
+        // DynamoDB batch delete has a limit of 25 items per request
+        for chunk in hmac_keys.chunks(25) {
+            let write_requests = chunk
+                .iter()
+                .map(|hmac_key| Self::build_delete_req(topic.to_string(), hmac_key.to_string()))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            self.dynamodb_client
+                .batch_write_item()
+                .request_items(&self.table_name, write_requests)
+                .send()
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Batch append deletion requests to multiple subscriptions
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic of the subscriptions
+    /// * `hmac_keys` - The HMAC keys of the subscriptions
+    /// * `encrypted_push_id` - The encrypted push ID to add to deletion requests
+    ///
+    /// # Errors
+    ///
+    /// Returns `PushSubscriptionStorageError` if the Dynamo DB operation fails
+    pub async fn batch_append_delete_requests(
+        &self,
+        topic: &str,
+        hmac_keys: &[String],
+        encrypted_push_id: &str,
+    ) -> PushSubscriptionStorageResult<()> {
+        // Use parallel update operations for efficiency
+        let futures: Vec<_> = hmac_keys
+            .iter()
+            .map(|hmac_key| self.append_delete_request(topic, hmac_key, encrypted_push_id))
+            .collect();
+
+        future::try_join_all(futures).await?;
+        Ok(())
+    }
+
+    /// Builds a delete request for a subscription
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic of the subscription
+    /// * `hmac_key` - The HMAC key of the subscription
+    ///
+    /// # Returns
+    ///
+    /// A delete request for the subscription
+    fn build_delete_req(
+        topic: String,
+        hmac_key: String,
+    ) -> PushSubscriptionStorageResult<WriteRequest> {
+        let key = HashMap::from([
+            (
+                PushSubscriptionAttribute::Topic.to_string(),
+                AttributeValue::S(topic),
+            ),
+            (
+                PushSubscriptionAttribute::HmacKey.to_string(),
+                AttributeValue::S(hmac_key),
+            ),
+        ]);
+
+        Ok(WriteRequest::builder()
+            .delete_request(
+                DeleteRequest::builder()
+                    .set_key(Some(key))
+                    .build()
+                    .map_err(|e| {
+                        PushSubscriptionStorageError::SerializationError(format!(
+                            "Failed to build delete request: {e:?}",
+                        ))
+                    })?,
+            )
+            .build())
     }
 }


### PR DESCRIPTION
This prepare adds batch db operations for an upcoming migration in the unsubscribe endpoint.

For context: We're going to change the unsubscribe endpoint and let the user unsubscribe by `{ topic, encrypted_push_id }`. 