### PR TITLE
chore: Remove auth from media endpoints (temporarily)

### DIFF
--- a/backend/src/routes/v1/mod.rs
+++ b/backend/src/routes/v1/mod.rs
@@ -12,14 +12,16 @@ use crate::middleware::auth::auth_middleware;
 
 /// Creates the v1 API router with all v1 handler routes
 pub fn handler() -> ApiRouter {
-    let public_routes = ApiRouter::new().api_route("/authorize", post(auth::authorize_handler));
-
-    let protected_routes = ApiRouter::new()
+    let public_routes = ApiRouter::new()
+        // TODO: TEMPORARY: Remove this once we finish mobile dev testing
         .api_route(
             "/media/presigned-urls",
             post(media::create_presigned_upload_url),
         )
         .api_route("/media/config", get(media::get_media_config))
+        .api_route("/authorize", post(auth::authorize_handler));
+
+    let protected_routes = ApiRouter::new()
         .api_route(
             "/subscriptions",
             post(subscriptions::subscribe).delete(subscriptions::unsubscribe),

--- a/backend/tests/auth_tests.rs
+++ b/backend/tests/auth_tests.rs
@@ -449,7 +449,9 @@ async fn test_validate_rejects_payload_tamper() {
     assert!(result.is_err(), "payload tamper should be rejected");
 }
 
+/// TODO: TEMPORARY: Remove this once we finish mobile dev testing
 #[tokio::test]
+#[ignore]
 async fn test_protected_endpoint_rejects_jwt_with_different_signing_key() {
     // Test with auth enabled
     let context = TestSetup::new(None, false).await;
@@ -589,7 +591,9 @@ async fn get_valid_jwt_token(context: &TestSetup) -> String {
         .to_string()
 }
 
+/// TODO: TEMPORARY: Remove this once we finish mobile dev testing
 #[tokio::test]
+#[ignore]
 async fn test_protected_endpoint_without_auth_header() {
     // Test with auth enabled (disable_auth = false)
     let context = TestSetup::new(None, false).await;
@@ -614,7 +618,9 @@ async fn test_protected_endpoint_without_auth_header() {
     );
 }
 
+/// TODO: TEMPORARY: Remove this once we finish mobile dev testing
 #[tokio::test]
+#[ignore]
 async fn test_protected_endpoint_with_invalid_auth_header() {
     // Test with auth enabled (disable_auth = false)
     let context = TestSetup::new(None, false).await;
@@ -643,7 +649,9 @@ async fn test_protected_endpoint_with_invalid_auth_header() {
     );
 }
 
+/// TODO: TEMPORARY: Remove this once we finish mobile dev testing
 #[tokio::test]
+#[ignore]
 async fn test_protected_endpoint_with_valid_token() {
     // Test with auth enabled (disable_auth = false)
     let context = TestSetup::new(None, false).await;


### PR DESCRIPTION
We'll add this back again once we finish mobile dev testing.