### PR TITLE
fix: Update hmac key expected size

### DIFF
--- a/backend/src/routes/v1/subscriptions.rs
+++ b/backend/src/routes/v1/subscriptions.rs
@@ -22,8 +22,8 @@ pub struct CreateSubscriptionRequest {
     /// Topic for the subscription
     #[schemars(length(min = 1))]
     pub topic: String,
-    /// HMAC key for subscription validation (64 hex characters)
-    #[schemars(length(equal = 64))]
+    /// HMAC key for subscription validation (42 bytes or 84 hex characters)
+    #[schemars(length(equal = 84))]
     pub hmac_key: String,
     /// TTL as unix timestamp
     #[schemars(
@@ -36,8 +36,8 @@ pub struct CreateSubscriptionRequest {
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub struct UnsubscribeRequest {
-    /// HMAC key for subscription validation (64 hex characters)
-    #[schemars(length(equal = 64))]
+    /// HMAC key for subscription validation (42 bytes or 84 hex characters)
+    #[schemars(length(equal = 84))]
     pub hmac_key: String,
     /// Topic to unsubscribe from
     #[schemars(length(min = 1))]

--- a/backend/tests/common/push_subscription_utils.rs
+++ b/backend/tests/common/push_subscription_utils.rs
@@ -5,7 +5,7 @@ use rand::{distributions::Alphanumeric, Rng};
 pub fn generate_hmac_key() -> String {
     rand::thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(64)
+        .take(84)
         .map(char::from)
         .collect()
 }


### PR DESCRIPTION
Correct hmac key size is 42 bytes as seen here: https://github.com/xmtp/libxmtp/blob/83fb508a46007b41af5afe478b778e16d6bf36da/xmtp_mls/src/groups/mls_sync.rs#L2511-L2514