### PR TITLE
chore: Rename to enclave worker API

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,9 +1,9 @@
 #![deny(clippy::all, clippy::pedantic, clippy::nursery, dead_code)]
 
+pub mod enclave_worker_api;
 pub mod jwt;
 pub mod media_storage;
 pub mod middleware;
-pub mod push_id_challenger;
 pub mod routes;
 pub mod server;
 pub mod types;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -6,9 +6,9 @@ use aws_sdk_s3::Client as S3Client;
 use backend_storage::{auth_proof::AuthProofStorage, push_subscription::PushSubscriptionStorage};
 
 use backend::{
+    enclave_worker_api::{EnclaveWorkerApi, EnclaveWorkerApiClient},
     jwt::JwtManager,
     media_storage::MediaStorage,
-    push_id_challenger::{PushIdChallenger, PushIdChallengerImpl},
     server,
     types::Environment,
 };
@@ -45,9 +45,10 @@ async fn main() -> anyhow::Result<()> {
         environment.dynamodb_push_subscription_table_name(),
     ));
 
-    // Initalize Push ID challenger
-    let push_id_challenger: Arc<dyn PushIdChallenger> =
-        Arc::new(PushIdChallengerImpl::new(environment.enclave_worker_url()));
+    // Initalize Enclave Worker API client
+    let enclave_worker_api: Arc<dyn EnclaveWorkerApi> = Arc::new(EnclaveWorkerApiClient::new(
+        environment.enclave_worker_url(),
+    ));
 
     let result = server::start(
         environment,
@@ -55,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
         jwt_manager,
         auth_proof_storage,
         push_subscription_storage,
-        push_id_challenger,
+        enclave_worker_api,
     )
     .await;
 

--- a/backend/src/routes/v1/auth.rs
+++ b/backend/src/routes/v1/auth.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use walletkit_core::CredentialType;
 
 use crate::{
+    enclave_worker_api::EnclaveWorkerApi,
     jwt::{JwsPayload, JwtManager},
-    push_id_challenger::PushIdChallenger,
     types::{AppError, Environment},
     world_id::{error::WorldIdError, verifier::verify_world_id_proof},
 };
@@ -57,7 +57,7 @@ pub async fn authorize_handler(
     Extension(jwt_manager): Extension<Arc<JwtManager>>,
     Extension(auth_proof_storage): Extension<Arc<AuthProofStorage>>,
     Extension(environment): Extension<Environment>,
-    Extension(push_id_challenger): Extension<Arc<dyn PushIdChallenger>>,
+    Extension(enclave_worker_api): Extension<Arc<dyn EnclaveWorkerApi>>,
     Json(request): Json<AuthRequest>,
 ) -> Result<Json<AuthResponse>, AppError> {
     // 1. Verify World ID proof
@@ -88,7 +88,7 @@ pub async fn authorize_handler(
     // - If the push ids don't match, but the push id rotation is within the threshold, reject the rotation
     // - Otherwise, rotate the push id and issue a JWT token with the new encrypted push id
     let push_id_action = {
-        let push_ids_match = push_id_challenger
+        let push_ids_match = enclave_worker_api
             .challenge_push_ids(
                 auth_proof.encrypted_push_id.clone(),
                 request.encrypted_push_id.clone(),

--- a/backend/src/server.rs
+++ b/backend/src/server.rs
@@ -7,7 +7,7 @@ use backend_storage::push_subscription::PushSubscriptionStorage;
 use datadog_tracing::axum::{shutdown_signal, OtelAxumLayer, OtelInResponseLayer};
 use tokio::net::TcpListener;
 
-use crate::push_id_challenger::PushIdChallenger;
+use crate::enclave_worker_api::EnclaveWorkerApi;
 use crate::routes;
 use crate::{jwt::JwtManager, media_storage::MediaStorage, types::Environment};
 
@@ -22,7 +22,7 @@ pub async fn start(
     jwt_manager: Arc<JwtManager>,
     auth_proof_storage: Arc<AuthProofStorage>,
     push_subscription_storage: Arc<PushSubscriptionStorage>,
-    push_id_challenger: Arc<dyn PushIdChallenger>,
+    enclave_worker_api: Arc<dyn EnclaveWorkerApi>,
 ) -> anyhow::Result<()> {
     let mut openapi = OpenApi::default();
 
@@ -34,7 +34,7 @@ pub async fn start(
         .layer(Extension(jwt_manager))
         .layer(Extension(auth_proof_storage))
         .layer(Extension(push_subscription_storage))
-        .layer(Extension(push_id_challenger))
+        .layer(Extension(enclave_worker_api))
         // Include trace context as header into the response
         .layer(OtelInResponseLayer)
         // Start OpenTelemetry trace on incoming request

--- a/backend/tests/common/test_setup.rs
+++ b/backend/tests/common/test_setup.rs
@@ -5,8 +5,8 @@ use aws_sdk_kms::types::{KeySpec, KeyUsageType};
 use aws_sdk_kms::Client as KmsClient;
 use aws_sdk_s3::Client as S3Client;
 use axum::{body::Body, http::Request, response::Response, Extension, Router};
-use backend::push_id_challenger::mock::MockPushIdChallenger;
-use backend::push_id_challenger::PushIdChallenger;
+use backend::enclave_worker_api::mock::MockEnclaveWorkerApiClient;
+use backend::enclave_worker_api::EnclaveWorkerApi;
 use backend::{jwt::JwtManager, media_storage::MediaStorage, routes, types::Environment};
 use backend_storage::auth_proof::AuthProofStorage;
 use backend_storage::push_subscription::PushSubscriptionStorage;
@@ -38,7 +38,7 @@ pub struct TestSetup {
     pub push_subscription_storage: Arc<PushSubscriptionStorage>,
     // Keep alive for the duration of the test
     _dynamodb_setup: DynamoDbTestSetup,
-    _push_id_challenger: Arc<dyn PushIdChallenger>,
+    _enclave_worker_api: Arc<dyn EnclaveWorkerApi>,
 }
 
 impl TestSetup {
@@ -87,8 +87,8 @@ impl TestSetup {
             dynamodb_test_setup.push_subscriptions_table_name.clone(),
         ));
 
-        let push_id_challenger: Arc<dyn PushIdChallenger> =
-            Arc::new(MockPushIdChallenger::new(None));
+        let enclave_worker_api: Arc<dyn EnclaveWorkerApi> =
+            Arc::new(MockEnclaveWorkerApiClient::new(None));
 
         let router = routes::handler()
             .layer(Extension(environment.clone()))
@@ -96,7 +96,7 @@ impl TestSetup {
             .layer(Extension(auth_proof_storage.clone()))
             .layer(Extension(jwt_manager.clone()))
             .layer(Extension(push_subscription_storage.clone()))
-            .layer(Extension(push_id_challenger.clone()))
+            .layer(Extension(enclave_worker_api.clone()))
             .into();
 
         Self {
@@ -105,7 +105,7 @@ impl TestSetup {
             media_storage,
             kms_client,
             push_subscription_storage,
-            _push_id_challenger: push_id_challenger,
+            _enclave_worker_api: enclave_worker_api,
             _dynamodb_setup: dynamodb_test_setup,
         }
     }

--- a/notification-worker/proto/mls/database/intents.proto
+++ b/notification-worker/proto/mls/database/intents.proto
@@ -38,6 +38,7 @@ message AddressesOrInstallationIds {
   }
 }
 
+// DEPRECATED
 // The data required to add members to a group
 message AddMembersData {
   // V1 of AddMembersPublishData
@@ -50,6 +51,7 @@ message AddMembersData {
   }
 }
 
+// DEPRECATED
 // The data required to remove members from a group
 message RemoveMembersData {
   // V1 of RemoveMembersPublishData
@@ -73,6 +75,19 @@ message UpdateGroupMembershipData {
     repeated string removed_members = 2;
     // List of installations that failed to be added due to errors encountered during the evaluation process.
     repeated bytes failed_installations = 3;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}
+
+// The data required to remove and readd existing leaf nodes
+// on the MLS tree. Does not change or update the members list.
+// Used for fork recovery
+message ReaddInstallationsData {
+  message V1 {
+    repeated bytes readded_installations = 1;
   }
 
   oneof version {

--- a/notification-worker/proto/mls/message_contents/content.proto
+++ b/notification-worker/proto/mls/message_contents/content.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 package xmtp.mls.message_contents;
 
 import "device_sync/content.proto";
-import "mls/message_contents/out_of_band.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
@@ -70,9 +69,11 @@ message PlaintextEnvelope {
       xmtp.device_sync.content.DeviceSyncReply device_sync_reply = 4;
       // A serialized user preference update
       xmtp.device_sync.content.V1UserPreferenceUpdate user_preference_update = 5;
-      // A readd request for fork recovery
-      ReaddRequest readd_request = 6;
     }
+
+    // Removed; moved to oneshot message
+    reserved 6;
+    reserved "readd_request";
   }
 
   // Selector which declares which version of the EncodedContent this

--- a/notification-worker/proto/mls/message_contents/group_metadata.proto
+++ b/notification-worker/proto/mls/message_contents/group_metadata.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 
 package xmtp.mls.message_contents;
 
+import "mls/message_contents/oneshot.proto";
+
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
 
@@ -14,6 +16,8 @@ message GroupMetadataV1 {
   string creator_inbox_id = 3;
   // Should only be present for CONVERSATION_TYPE_DM
   optional DmMembers dm_members = 4;
+  // Should only be present for CONVERSATION_TYPE_ONESHOT
+  optional xmtp.mls.message_contents.OneshotMessage oneshot_message = 5;
 }
 
 // Defines the type of conversation
@@ -22,6 +26,7 @@ enum ConversationType {
   CONVERSATION_TYPE_GROUP = 1;
   CONVERSATION_TYPE_DM = 2;
   CONVERSATION_TYPE_SYNC = 3;
+  CONVERSATION_TYPE_ONESHOT = 4;
 }
 
 // Wrapper around an Inbox Id

--- a/notification-worker/proto/mls/message_contents/group_mutable_metadata.proto
+++ b/notification-worker/proto/mls/message_contents/group_mutable_metadata.proto
@@ -14,9 +14,9 @@ message GroupMutableMetadataV1 {
   // Creator starts as only super_admin
   // Only super_admin can add/remove other super_admin
   Inboxes super_admin_list = 3;
-  // The ED25519 private key used to sign commit log entries
-  // Must match the first entry in the commit log to be valid
-  optional bytes commit_log_signer = 4;
+  // Top-level commit_log_signer removed in favor of attribute
+  reserved 4;
+  reserved "commit_log_signer";
 }
 
 // Wrapper around a list of repeated Inbox Ids

--- a/notification-worker/proto/mls/message_contents/oneshot.proto
+++ b/notification-worker/proto/mls/message_contents/oneshot.proto
@@ -4,10 +4,19 @@ syntax = "proto3";
 
 package xmtp.mls.message_contents;
 
+message OneshotMessage {
+  oneof message_type {
+    ReaddRequest readd_request = 1;
+  }
+}
+
 // A request sent by an installation to recover from a fork. Other members
 // may remove and readd that installation from the group.
 // XIP: https://community.xmtp.org/t/xip-68-draft-automated-fork-recovery/951
 message ReaddRequest {
   bytes group_id = 1;
-  uint64 commit_log_epoch = 2;
+  // The sequence ID of the latest commit log entry at the time the request
+  // is sent; used to disambiguate cases where an installation forks
+  // and is readded multiple times.
+  uint64 latest_commit_sequence_id = 2;
 }


### PR DESCRIPTION
This PR renames the `PushIdChallenger` module to `EnclaveWorkerApi` to represent it's actual use. This module will used for other endpoints as well in the future, eg. retreiving attestation document. 

Proto files was also updated because it was out of sync.