### PR TITLE
feat: Add attestation document endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
 name = "common-types"
 version = "0.1.0"
 dependencies = [
+ "schemars 0.8.22",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -2304,6 +2305,8 @@ dependencies = [
  "axum 0.7.9",
  "axum-jsonschema",
  "backend_storage",
+ "base64 0.22.1",
+ "common-types",
  "datadog-tracing",
  "enclave-types",
  "pontifex",

--- a/backend/src/routes/v1/attestation.rs
+++ b/backend/src/routes/v1/attestation.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum_jsonschema::Json;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::{enclave_worker_api::EnclaveWorkerApi, types::AppError};
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AttestationDocumentResponse {
+    /// Base-64 encoded attestation document.
+    pub attestation_doc_base64: String,
+}
+
+/// Get the attestation document from the enclave
+///
+/// # Errors
+///
+/// If the enclave worker API returns an error, it will be returned.
+pub async fn handler(
+    Extension(enclave_worker_api): Extension<Arc<dyn EnclaveWorkerApi>>,
+) -> Result<Json<AttestationDocumentResponse>, AppError> {
+    let response = enclave_worker_api.get_attestation_document().await?;
+
+    Ok(Json(AttestationDocumentResponse {
+        attestation_doc_base64: response.attestation_doc_base64,
+    }))
+}

--- a/backend/src/routes/v1/mod.rs
+++ b/backend/src/routes/v1/mod.rs
@@ -1,3 +1,4 @@
+pub mod attestation;
 pub mod auth;
 pub mod media;
 pub mod subscriptions;
@@ -18,6 +19,7 @@ pub fn handler() -> ApiRouter {
             "/media/presigned-urls",
             post(media::create_presigned_upload_url),
         )
+        .api_route("/attestation", get(attestation::handler))
         .api_route("/media/config", get(media::get_media_config))
         .api_route("/authorize", post(auth::authorize_handler));
 

--- a/backend/src/routes/v1/mod.rs
+++ b/backend/src/routes/v1/mod.rs
@@ -19,7 +19,7 @@ pub fn handler() -> ApiRouter {
             "/media/presigned-urls",
             post(media::create_presigned_upload_url),
         )
-        .api_route("/attestation", get(attestation::handler))
+        .api_route("/attestation-document", get(attestation::handler))
         .api_route("/media/config", get(media::get_media_config))
         .api_route("/authorize", post(auth::authorize_handler));
 

--- a/backend/tests/common/test_setup.rs
+++ b/backend/tests/common/test_setup.rs
@@ -88,7 +88,7 @@ impl TestSetup {
         ));
 
         let enclave_worker_api: Arc<dyn EnclaveWorkerApi> =
-            Arc::new(MockEnclaveWorkerApiClient::new(None));
+            Arc::new(MockEnclaveWorkerApiClient::new(None, None));
 
         let router = routes::handler()
             .layer(Extension(environment.clone()))

--- a/enclave-worker/Cargo.toml
+++ b/enclave-worker/Cargo.toml
@@ -45,3 +45,6 @@ reqwest = { workspace = true }
 pontifex = { workspace = true, features = ["client"] }
 
 enclave-types = { workspace = true }
+common-types = { workspace = true }
+
+base64 = { workspace = true }

--- a/enclave-worker/src/lib.rs
+++ b/enclave-worker/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all, clippy::pedantic, clippy::nursery, dead_code)]
+
 pub mod notification_processor;
 pub mod routes;
 pub mod server;

--- a/enclave-worker/src/notification_processor/mod.rs
+++ b/enclave-worker/src/notification_processor/mod.rs
@@ -20,6 +20,12 @@ pub struct NotificationProcessor {
 }
 
 impl NotificationProcessor {
+    /// Creates a new `NotificationProcessor`
+    ///
+    /// # Panics
+    ///
+    /// If the HTTP client fails to create, this will panic.
+    #[must_use]
     pub fn new(
         queue: Arc<NotificationQueue>,
         storage: Arc<PushSubscriptionStorage>,
@@ -54,7 +60,7 @@ impl NotificationProcessor {
         while !self.shutdown.is_cancelled() {
             tokio::select! {
                 _ = self.poll_once() => {},
-                _ = self.shutdown.cancelled() => {
+                () = self.shutdown.cancelled() => {
                     info!("Queue poller shutting down");
                     break;
                 }

--- a/enclave-worker/src/routes/attestation.rs
+++ b/enclave-worker/src/routes/attestation.rs
@@ -17,6 +17,6 @@ pub async fn handler(
             .await??;
 
     Ok(Json(AttestationDocumentResponse {
-        attestation: STANDARD.encode(response.attestation),
+        attestation_doc_base64: STANDARD.encode(response.attestation),
     }))
 }

--- a/enclave-worker/src/routes/attestation.rs
+++ b/enclave-worker/src/routes/attestation.rs
@@ -1,0 +1,22 @@
+use axum::Extension;
+use axum_jsonschema::Json;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use common_types::AttestationDocumentResponse;
+use enclave_types::EnclavePublicKeyRequest;
+
+use crate::types::AppError;
+
+pub async fn handler(
+    Extension(pontifex_connection_details): Extension<pontifex::client::ConnectionDetails>,
+) -> Result<Json<AttestationDocumentResponse>, AppError> {
+    let request = EnclavePublicKeyRequest {};
+
+    let response =
+        pontifex::client::send::<EnclavePublicKeyRequest>(pontifex_connection_details, &request)
+            .await??;
+
+    Ok(Json(AttestationDocumentResponse {
+        attestation: STANDARD.encode(response.attestation),
+    }))
+}

--- a/enclave-worker/src/routes/attestation.rs
+++ b/enclave-worker/src/routes/attestation.rs
@@ -3,18 +3,20 @@ use axum_jsonschema::Json;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use common_types::AttestationDocumentResponse;
-use enclave_types::EnclavePublicKeyRequest;
+use enclave_types::EnclaveAttestationDocRequest;
 
 use crate::types::AppError;
 
 pub async fn handler(
     Extension(pontifex_connection_details): Extension<pontifex::client::ConnectionDetails>,
 ) -> Result<Json<AttestationDocumentResponse>, AppError> {
-    let request = EnclavePublicKeyRequest {};
+    let request = EnclaveAttestationDocRequest {};
 
-    let response =
-        pontifex::client::send::<EnclavePublicKeyRequest>(pontifex_connection_details, &request)
-            .await??;
+    let response = pontifex::client::send::<EnclaveAttestationDocRequest>(
+        pontifex_connection_details,
+        &request,
+    )
+    .await??;
 
     Ok(Json(AttestationDocumentResponse {
         attestation_doc_base64: STANDARD.encode(response.attestation),

--- a/enclave-worker/src/routes/mod.rs
+++ b/enclave-worker/src/routes/mod.rs
@@ -1,3 +1,4 @@
+mod attestation;
 mod docs;
 mod health;
 mod push_id_challenge;
@@ -13,4 +14,5 @@ pub fn handler() -> ApiRouter {
         .merge(docs::handler())
         .api_route("/health", get(health::handler))
         .api_route("/v1/push-id-challenge", post(push_id_challenge::handler))
+        .api_route("/v1/attestation-document", get(attestation::handler))
 }

--- a/secure-enclave/src/pontifex_server/mod.rs
+++ b/secure-enclave/src/pontifex_server/mod.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use enclave_types::{EnclaveHealthCheckRequest, EnclaveInitializeRequest, EnclavePublicKeyRequest};
+use enclave_types::{
+    EnclaveAttestationDocRequest, EnclaveHealthCheckRequest, EnclaveInitializeRequest,
+};
 use pontifex::Router;
 use tokio::sync::RwLock;
 mod health;
@@ -18,7 +20,7 @@ pub async fn start_pontifex_server(
     let router = Router::with_state(state)
         .route::<EnclaveInitializeRequest, _, _>(initialize::handler)
         .route::<EnclaveHealthCheckRequest, _, _>(health::handler)
-        .route::<EnclavePublicKeyRequest, _, _>(public_key::handler);
+        .route::<EnclaveAttestationDocRequest, _, _>(public_key::handler);
 
     // Start pontifex server
     router

--- a/secure-enclave/src/pontifex_server/public_key.rs
+++ b/secure-enclave/src/pontifex_server/public_key.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use crate::state::EnclaveState;
-use enclave_types::{EnclaveError, EnclavePublicKeyRequest, EnclavePublicKeyResponse};
+use enclave_types::{EnclaveAttestationDocRequest, EnclaveAttestationDocResponse, EnclaveError};
 use pontifex::SecureModule;
 use tokio::sync::RwLock;
 
 pub async fn handler(
     state: Arc<RwLock<EnclaveState>>,
-    _: EnclavePublicKeyRequest,
-) -> Result<EnclavePublicKeyResponse, EnclaveError> {
+    _: EnclaveAttestationDocRequest,
+) -> Result<EnclaveAttestationDocResponse, EnclaveError> {
     let public_key = state.read().await.keys.public_key.to_bytes().to_vec();
     let nsm = SecureModule::try_global().ok_or(EnclaveError::SecureModuleNotInitialized)?;
 
@@ -19,5 +19,5 @@ pub async fn handler(
             EnclaveError::AttestationFailed()
         })?;
 
-    Ok(EnclavePublicKeyResponse { attestation })
+    Ok(EnclaveAttestationDocResponse { attestation })
 }

--- a/shared/common-types/Cargo.toml
+++ b/shared/common-types/Cargo.toml
@@ -11,3 +11,4 @@ thiserror = { workspace = true }
 # Serialization
 serde = { workspace = true }
 
+schemars = { workspace = true }

--- a/shared/common-types/src/lib.rs
+++ b/shared/common-types/src/lib.rs
@@ -12,7 +12,7 @@ pub struct PushIdChallengeResponse {
     pub push_ids_match: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct AttestationDocumentResponse {
-    pub attestation: String,
+    pub attestation_doc_base64: String,
 }

--- a/shared/common-types/src/lib.rs
+++ b/shared/common-types/src/lib.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -9,4 +10,9 @@ pub struct PushIdChallengeRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PushIdChallengeResponse {
     pub push_ids_match: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct AttestationDocumentResponse {
+    pub attestation: String,
 }

--- a/shared/enclave-types/src/lib.rs
+++ b/shared/enclave-types/src/lib.rs
@@ -44,15 +44,15 @@ impl Request for EnclaveHealthCheckRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EnclavePublicKeyRequest;
+pub struct EnclaveAttestationDocRequest;
 
-impl Request for EnclavePublicKeyRequest {
-    const ROUTE_ID: &'static str = "/v1/public-key";
-    type Response = Result<EnclavePublicKeyResponse, EnclaveError>;
+impl Request for EnclaveAttestationDocRequest {
+    const ROUTE_ID: &'static str = "/v1/attestation-doc";
+    type Response = Result<EnclaveAttestationDocResponse, EnclaveError>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EnclavePublicKeyResponse {
+pub struct EnclaveAttestationDocResponse {
     /// Attestation document bytes
     pub attestation: Vec<u8>,
 }


### PR DESCRIPTION
Adds attestation document endpoint. Will improve later by adding a cache layer like we did in DF service