### PR TITLE
feat: Update enclave worker url parsing

### DIFF
--- a/backend/src/types/environment.rs
+++ b/backend/src/types/environment.rs
@@ -252,17 +252,8 @@ impl Environment {
     #[must_use]
     pub fn enclave_worker_url(&self) -> String {
         match self {
-            Self::Production | Self::Staging => {
-                let url = env::var("ENCLAVE_WORKER_URL")
-                    .expect("ENCLAVE_WORKER_URL environment variable is not set");
-
-                assert!(
-                    url.starts_with("https://"),
-                    "Enclave Worker URL in Production/Staging must use https"
-                );
-
-                url
-            }
+            Self::Production | Self::Staging => env::var("ENCLAVE_WORKER_URL")
+                .expect("ENCLAVE_WORKER_URL environment variable is not set"),
             Self::Development { .. } => "http://localhost:8002".to_string(),
         }
     }


### PR DESCRIPTION
We don't need to force https here, the way to secure `backend` is talking to `secure-enclave` is by introducing signatures.

This PR unblocks dev integration with mobile clients, will revisit this later.