### PR TITLE
feat: Implement push id challenge flow (secure-enclave)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,6 +2329,7 @@ dependencies = [
  "datadog-tracing",
  "dotenvy",
  "enclave-types",
+ "hex",
  "metrics",
  "metrics-exporter-dogstatsd",
  "pontifex",

--- a/enclave-worker/Cargo.toml
+++ b/enclave-worker/Cargo.toml
@@ -50,6 +50,7 @@ enclave-types = { workspace = true }
 common-types = { workspace = true }
 
 base64 = { workspace = true }
+hex = { workspace = true }
 
 redis = { workspace = true, features = ["tokio-comp", "aio", "connection-manager"]}
 

--- a/enclave-worker/src/routes/push_id_challenge.rs
+++ b/enclave-worker/src/routes/push_id_challenge.rs
@@ -9,9 +9,16 @@ pub async fn handler(
     Extension(pontifex_connection_details): Extension<pontifex::client::ConnectionDetails>,
     Json(payload): Json<PushIdChallengeRequest>,
 ) -> Result<Json<PushIdChallengeResponse>, AppError> {
+    let encrypted_push_id_1 = hex::decode(payload.encrypted_push_id_1).map_err(|e| {
+        AppError::bad_request("invalid_encrypted_push_id_1", "Invalid encrypted push ID 1")
+    })?;
+    let encrypted_push_id_2 = hex::decode(payload.encrypted_push_id_2).map_err(|e| {
+        AppError::bad_request("invalid_encrypted_push_id_2", "Invalid encrypted push ID 2")
+    })?;
+
     let pontifex_request = EnclavePushIdChallengeRequest {
-        encrypted_push_id_1: payload.encrypted_push_id_1,
-        encrypted_push_id_2: payload.encrypted_push_id_2,
+        encrypted_push_id_1,
+        encrypted_push_id_2,
     };
 
     let response = pontifex::client::send::<EnclavePushIdChallengeRequest>(

--- a/enclave-worker/src/types/error.rs
+++ b/enclave-worker/src/types/error.rs
@@ -65,6 +65,11 @@ impl AppError {
             false,
         )
     }
+
+    #[must_use]
+    pub const fn bad_request(code: &'static str, msg: &'static str) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, code, msg, false)
+    }
 }
 
 impl IntoResponse for AppError {
@@ -162,7 +167,8 @@ impl From<enclave_types::EnclaveError> for AppError {
     #[allow(clippy::cognitive_complexity)]
     fn from(err: enclave_types::EnclaveError) -> Self {
         use enclave_types::EnclaveError::{
-            AttestationFailed, BrazeRequestFailed, NotInitialized, SecureModuleNotInitialized,
+            AttestationFailed, BrazeRequestFailed, DecryptPushIdFailed, NotInitialized,
+            SecureModuleNotInitialized,
         };
 
         match &err {
@@ -195,6 +201,15 @@ impl From<enclave_types::EnclaveError> for AppError {
             }
             BrazeRequestFailed(msg) => {
                 tracing::error!("Braze request failed: {msg}");
+                Self::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_error",
+                    "Internal server error",
+                    false,
+                )
+            }
+            DecryptPushIdFailed(msg) => {
+                tracing::error!("Decrypt push ID failed: {msg}");
                 Self::new(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "internal_error",

--- a/secure-enclave/src/pontifex_server/mod.rs
+++ b/secure-enclave/src/pontifex_server/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use enclave_types::{
     EnclaveAttestationDocRequest, EnclaveHealthCheckRequest, EnclaveInitializeRequest,
-    EnclaveNotificationRequest,
+    EnclaveNotificationRequest, EnclavePushIdChallengeRequest,
 };
 use pontifex::Router;
 use tokio::sync::RwLock;
@@ -12,6 +12,7 @@ mod health;
 mod initialize;
 mod notification;
 mod public_key;
+mod push_id_challenge;
 
 use crate::state::EnclaveState;
 
@@ -24,6 +25,7 @@ pub async fn start_pontifex_server(
         .route::<EnclaveInitializeRequest, _, _>(initialize::handler)
         .route::<EnclaveHealthCheckRequest, _, _>(health::handler)
         .route::<EnclaveAttestationDocRequest, _, _>(public_key::handler)
+        .route::<EnclavePushIdChallengeRequest, _, _>(push_id_challenge::handler)
         .route::<EnclaveNotificationRequest, _, _>(notification::handler);
 
     // Start pontifex server

--- a/secure-enclave/src/pontifex_server/push_id_challenge.rs
+++ b/secure-enclave/src/pontifex_server/push_id_challenge.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use enclave_types::{EnclaveError, EnclavePushIdChallengeRequest};
+use tokio::sync::RwLock;
+
+use crate::state::EnclaveState;
+
+pub async fn handler(
+    state: Arc<RwLock<EnclaveState>>,
+    request: EnclavePushIdChallengeRequest,
+) -> Result<bool, EnclaveError> {
+    let state = state.read().await;
+    let encryption_key = state.keys.private_key.clone();
+
+    let decrypted_push_id_1 = encryption_key
+        .unseal(&request.encrypted_push_id_1)
+        .map_err(|e| EnclaveError::DecryptPushIdFailed(e.to_string()))?;
+    let decrypted_push_id_2 = encryption_key
+        .unseal(&request.encrypted_push_id_2)
+        .map_err(|e| EnclaveError::DecryptPushIdFailed(e.to_string()))?;
+
+    let push_ids_match = decrypted_push_id_1 == decrypted_push_id_2;
+
+    Ok(push_ids_match)
+}

--- a/shared/enclave-types/src/lib.rs
+++ b/shared/enclave-types/src/lib.rs
@@ -13,6 +13,8 @@ pub enum EnclaveError {
     AttestationFailed(),
     #[error("Failed to send request to Braze: {0}")]
     BrazeRequestFailed(String),
+    #[error("Failed to decrypt push ID: {0}")]
+    DecryptPushIdFailed(String),
 }
 
 /// Braze API configuration
@@ -55,8 +57,8 @@ pub struct EnclaveAttestationDocResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnclavePushIdChallengeRequest {
-    pub encrypted_push_id_1: String,
-    pub encrypted_push_id_2: String,
+    pub encrypted_push_id_1: Vec<u8>,
+    pub encrypted_push_id_2: Vec<u8>,
 }
 
 impl Request for EnclavePushIdChallengeRequest {


### PR DESCRIPTION
This PR completes the final piece of the push id challenge flow, by implementing the pontifex route on the secure-enclave, that decrypted the push ids and returns a boolean if they're true.

TODO: Add signature for push id comparison, this is still TBD, will come back to this.