### PR TITLE
feat(storage): Add enclave_track to push subscription table 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "aws-sdk-sqs",
  "chrono",
+ "common-types",
  "futures",
  "pretty_assertions",
  "rand 0.8.5",
@@ -1828,6 +1829,7 @@ version = "0.1.0"
 dependencies = [
  "schemars 0.9.0",
  "serde",
+ "strum",
  "thiserror 2.0.17",
 ]
 
@@ -3772,6 +3774,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "common-types",
  "datadog-tracing",
  "dotenvy",
  "flume",

--- a/backend/src/routes/v1/subscriptions.rs
+++ b/backend/src/routes/v1/subscriptions.rs
@@ -9,6 +9,7 @@ use validator::Validate;
 
 use crate::{middleware::AuthenticatedUser, types::AppError};
 use backend_storage::push_subscription::{PushSubscription, PushSubscriptionStorage};
+use common_types::EnclaveTrack;
 
 /// In the context of XMTP hmac keys for a conversation are rotated every 30-day epoch cycle
 /// We set a maximum of 40 days to prevent bad actors subscribing to a topic for a longer period of time
@@ -121,6 +122,7 @@ pub async fn subscribe(
             topic: s.topic,
             ttl: s.ttl,
             encrypted_push_id: user.encrypted_push_id.clone(),
+            enclave_track: EnclaveTrack::default(),
         })
         .collect::<Vec<PushSubscription>>();
 

--- a/backend/tests/common/push_subscription_utils.rs
+++ b/backend/tests/common/push_subscription_utils.rs
@@ -1,5 +1,6 @@
 use super::TestSetup;
 use chrono::Utc;
+use common_types::EnclaveTrack;
 use rand::{distributions::Alphanumeric, Rng};
 
 pub fn generate_hmac_key() -> String {
@@ -39,6 +40,7 @@ pub async fn create_subscription(
         ttl: Utc::now().timestamp() + 3600,
         encrypted_push_id: encrypted_push_id.to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
 
     context

--- a/notification-worker/Cargo.toml
+++ b/notification-worker/Cargo.toml
@@ -55,6 +55,7 @@ metrics-exporter-dogstatsd = { workspace = true }
 serial_test = { workspace = true }
 dotenvy = { workspace = true }
 pretty_assertions = "1.4.1"
+common-types = { path = "../shared/common-types" }
 
 # Build dependencies
 [build-dependencies]

--- a/notification-worker/tests/message_filtering_tests.rs
+++ b/notification-worker/tests/message_filtering_tests.rs
@@ -4,6 +4,7 @@ mod utils;
 use anyhow::Context;
 use anyhow::Result;
 use backend_storage::push_subscription::PushSubscription;
+use common_types::EnclaveTrack;
 use notification_worker::xmtp::message_api::v1::Envelope;
 use notification_worker::xmtp::mls::api::v1::{group_message, GroupMessage};
 use pretty_assertions::assert_eq;
@@ -49,6 +50,7 @@ async fn setup_test_subscriptions(ctx: &TestContext) -> Result<TestSubscriptions
         ttl: now + 86400, // Valid for 1 day
         encrypted_push_id: "push_id_x".to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
 
     // Topic B with multiple subscribers
@@ -58,6 +60,7 @@ async fn setup_test_subscriptions(ctx: &TestContext) -> Result<TestSubscriptions
         ttl: now + 86400,
         encrypted_push_id: "push_id_x".to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
 
     let sub_b_y1 = PushSubscription {
@@ -66,6 +69,7 @@ async fn setup_test_subscriptions(ctx: &TestContext) -> Result<TestSubscriptions
         ttl: now + 86400,
         encrypted_push_id: "push_id_y".to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
 
     // Same push_id as y1 (same device, different installation)
@@ -75,6 +79,7 @@ async fn setup_test_subscriptions(ctx: &TestContext) -> Result<TestSubscriptions
         ttl: now + 86400,
         encrypted_push_id: "push_id_y".to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
 
     // Insert all subscriptions
@@ -357,6 +362,7 @@ async fn test_welcome_messages() -> Result<()> {
         ttl: chrono::Utc::now().timestamp() + 86400,
         encrypted_push_id: "welcome_push_id".to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
     ctx.subscription_storage.insert(&subscription).await?;
 
@@ -385,6 +391,7 @@ async fn test_ignores_non_v3_topics() -> Result<()> {
         ttl: chrono::Utc::now().timestamp() + 86400,
         encrypted_push_id: "legacy_push_id".to_string(),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     };
     ctx.subscription_storage.insert(&subscription).await?;
 
@@ -471,6 +478,7 @@ async fn test_duplicate_push_ids_deduplicated() -> Result<()> {
             ttl: now + 86400,
             encrypted_push_id: "duplicate_push_id".to_string(),
             deletion_request: None,
+            enclave_track: EnclaveTrack::default(),
         };
         ctx.subscription_storage.insert(&sub).await?;
     }

--- a/shared/backend_storage/Cargo.toml
+++ b/shared/backend_storage/Cargo.toml
@@ -10,6 +10,9 @@ aws-config = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
 aws-sdk-sqs = { workspace = true }
 
+# Common types
+common-types = { path = "../common-types" }
+
 # Async
 tokio = { workspace = true }
 

--- a/shared/backend_storage/src/push_subscription/mod.rs
+++ b/shared/backend_storage/src/push_subscription/mod.rs
@@ -11,6 +11,7 @@ use aws_sdk_dynamodb::{
     types::{AttributeValue, DeleteRequest, KeysAndAttributes, Select, WriteRequest},
     Client as DynamoDbClient,
 };
+use common_types::EnclaveTrack;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -43,6 +44,8 @@ pub enum PushSubscriptionAttribute {
     EncryptedPushId,
     /// Optional set of deletion request strings
     DeletionRequest,
+    /// Enclave track version
+    EnclaveTrack,
 }
 
 /// Push subscription data structure
@@ -59,6 +62,9 @@ pub struct PushSubscription {
     /// Optional set of deletion request strings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletion_request: Option<std::collections::HashSet<String>>,
+    /// Enclave track version used when creating the subscription
+    #[serde(default)]
+    pub enclave_track: EnclaveTrack,
 }
 
 /// Push notification storage client for Dynamo DB operations

--- a/shared/backend_storage/tests/push_subscription_table_tests.rs
+++ b/shared/backend_storage/tests/push_subscription_table_tests.rs
@@ -12,6 +12,7 @@ use backend_storage::push_subscription::{
     PushSubscription, PushSubscriptionAttribute, PushSubscriptionStorage,
 };
 use chrono::Utc;
+use common_types::EnclaveTrack;
 use uuid::Uuid;
 
 /// Test configuration for LocalStack
@@ -133,6 +134,7 @@ fn create_test_subscription(topic: &str) -> PushSubscription {
         ttl: (Utc::now() + chrono::Duration::hours(24)).timestamp(),
         encrypted_push_id: format!("encrypted-{}", Uuid::new_v4()),
         deletion_request: None,
+        enclave_track: EnclaveTrack::default(),
     }
 }
 
@@ -152,6 +154,7 @@ fn create_test_subscription_with_deletion(
         ttl: (Utc::now() + chrono::Duration::hours(24)).timestamp(),
         encrypted_push_id: format!("encrypted-{}", Uuid::new_v4()),
         deletion_request: Some(deletion_set),
+        enclave_track: EnclaveTrack::default(),
     }
 }
 

--- a/shared/common-types/Cargo.toml
+++ b/shared/common-types/Cargo.toml
@@ -12,3 +12,6 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 
 schemars = { workspace = true }
+
+# Enum utilities
+strum = { workspace = true }

--- a/shared/common-types/src/lib.rs
+++ b/shared/common-types/src/lib.rs
@@ -1,5 +1,23 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use strum::Display;
+
+/// Enclave track version identifier.
+///
+/// Each track has its own encryption keys and PCR values.
+/// This enables supporting multiple enclave versions simultaneously,
+/// allowing gradual app rollouts when enclave code changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Display, Default)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum EnclaveTrack {
+    /// Version 2 enclave track (initial production release)
+    #[default]
+    V2,
+    // TODO: V3 is a placeholder for the next enclave track
+    /// Version 3 enclave track (placeholder for future release)
+    V3,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PushIdChallengeRequest {


### PR DESCRIPTION
This PR part of a bigger feature (DEV-2458) introducing multi-enclave support, essentially allowing multiple enclave sets running at once. 

Our current setup assumes we never upgrade our enclave code and that all push ids are encrypted to the same enclave public key.

This PR introduces `enclave_track` to the push storage table, which will be used later to route the notification to the correct enclave. 